### PR TITLE
Add modeline to plugin/litedfm.vim

### DIFF
--- a/plugin/litedfm.vim
+++ b/plugin/litedfm.vim
@@ -172,3 +172,4 @@ endfunction
 command! LiteDFM call LiteDFM()
 command! LiteDFMClose call LiteDFMClose()
 command! LiteDFMToggle call LiteDFMToggle()
+" vim: tabstop=2


### PR DESCRIPTION
This makes sure people don't mess up the indentation by mistake.
We don't use exrc because most people don't have that option on.